### PR TITLE
Basp-MR-51: Create Admins tests for post/get

### DIFF
--- a/src/tests/admins.test.js
+++ b/src/tests/admins.test.js
@@ -4,27 +4,36 @@ import adminsSeed from '../seeds/admins';
 const app = require('../app');
 const Admin = require('../models/Admins');
 
-// const mockAdmin = {
-//   firstName: 'Jose',
-//   lastName: 'Daniele',
-//   dni: 43491185,
-//   phone: '3413755012',
-//   email: 'josedaniele@example.com',
-//   city: 'Rosario',
-//   password: 'AUhiygwb12356',
-// };
+const mockAdmin = {
+  firstName: 'Jose',
+  lastName: 'Daniele',
+  dni: 43491185,
+  phone: '3413755012',
+  email: 'josedaniele@example.com',
+  city: 'Rosario',
+  password: 'AUhiygwb12356',
+};
+const mockAdminBad = {
+  firstName: 'Jos2',
+  lastName: 'Daniel9',
+  dni: 'HBUi6',
+  phone: '3413755012',
+  email: 'josedaniele',
+  city: 'Rosario',
+  password: 'AUhiygw',
+};
 
 beforeAll(async () => {
   await Admin.collection.insertMany(adminsSeed);
 });
 
 describe('GET /api/admins', () => {
-  test('should return status 200', async () => {
+  test('get all admins should return status 200', async () => {
     const response = await request(app).get('/api/admins').send();
     expect(response.status).toBe(200);
     expect(response.error).toBeFalsy();
   });
-  test('should return status 404', async () => {
+  test('get all admins with bad route should return status 404', async () => {
     const response = await request(app).get('/api/admin').send();
     expect(response.status).toBe(404);
     expect(response.error).toBeTruthy();
@@ -32,19 +41,32 @@ describe('GET /api/admins', () => {
 });
 
 describe('GETBYID /api/admins/:id', () => {
-  test('should return status 200', async () => {
+  test('get an admin by id should return status 200', async () => {
     const response = await request(app).get('/api/admins/617a9f7af043b719c23928f2').send();
     expect(response.status).toBe(200);
     expect(response.error).toBeFalsy();
   });
-  test('should return status 404', async () => {
+  test('get an admin for nonexistent id should return status 404', async () => {
     const response = await request(app).get('/api/admin/617a9f7af043b719c23929f4').send();
     expect(response.status).toBe(404);
     expect(response.error).toBeTruthy();
   });
-  test('should return status 500', async () => {
+  test('getting an admin by id in bad format should return status 500', async () => {
     const response = await request(app).get('/api/admins/617a9f7af043b719c23928').send();
     expect(response.status).toBe(500);
+    expect(response.error).toBeTruthy();
+  });
+});
+
+describe('POST /api/admins', () => {
+  test('creating an admin should return status 201', async () => {
+    const response = await request(app).post('/api/admins').send(mockAdmin);
+    expect(response.status).toBe(201);
+    expect(response.error).toBeFalsy();
+  });
+  test('create an admin with a bad body should return status 400', async () => {
+    const response = await request(app).post('/api/admins').send(mockAdminBad);
+    expect(response.status).toBe(400);
     expect(response.error).toBeTruthy();
   });
 });

--- a/src/tests/admins.test.js
+++ b/src/tests/admins.test.js
@@ -1,5 +1,50 @@
-// Basic test to avoid conflicts
-// REMOVE THIS TEST AND MAKE YOURS!
-test('should pass a basic test', () => {
-  expect(1 + 1).toBe(2);
+import request from 'supertest';
+import adminsSeed from '../seeds/admins';
+
+const app = require('../app');
+const Admin = require('../models/Admins');
+
+// const mockAdmin = {
+//   firstName: 'Jose',
+//   lastName: 'Daniele',
+//   dni: 43491185,
+//   phone: '3413755012',
+//   email: 'josedaniele@example.com',
+//   city: 'Rosario',
+//   password: 'AUhiygwb12356',
+// };
+
+beforeAll(async () => {
+  await Admin.collection.insertMany(adminsSeed);
+});
+
+describe('GET /api/admins', () => {
+  test('should return status 200', async () => {
+    const response = await request(app).get('/api/admins').send();
+    expect(response.status).toBe(200);
+    expect(response.error).toBeFalsy();
+  });
+  test('should return status 404', async () => {
+    const response = await request(app).get('/api/admin').send();
+    expect(response.status).toBe(404);
+    expect(response.error).toBeTruthy();
+  });
+});
+
+describe('GETBYID /api/admins/:id', () => {
+  test('should return status 200', async () => {
+    const response = await request(app).get('/api/admins/617a9f7af043b719c23928f2').send();
+    expect(response.status).toBe(200);
+    expect(response.error).toBeFalsy();
+  });
+  test('should return status 404', async () => {
+    const response = await request(app).get('/api/admin/617a9f7af043b719c23929f4').send();
+    expect(response.status).toBe(404);
+    expect(response.error).toBeTruthy();
+  });
+  test('should return status 500', async () => {
+    const response = await request(app).get('/api/admins/617a9f7af043b719c23928').send();
+    expect(response.status).toBe(500);
+    expect(response.error).toBeTruthy();
+  });
 });


### PR DESCRIPTION
This PR includes different tests for the Admin entity, specifically targeting the "get", "getById", and "post" methods.