### PR TITLE
BaSP-MR-83: class get methods issues fixed

### DIFF
--- a/src/models/Class.js
+++ b/src/models/Class.js
@@ -15,7 +15,7 @@ const classSchema = new Schema({
   },
   trainer: {
     type: [Schema.Types.ObjectId],
-    ref: 'trainer',
+    ref: 'Trainer',
     required: true,
   },
   activity: {


### PR DESCRIPTION
Fix issue that broke classes "get" methods, it was a syntax error in the model.