### PR TITLE
BaSP-MR-330: Sign up member firstName regex

### DIFF
--- a/src/models/Member.js
+++ b/src/models/Member.js
@@ -12,14 +12,14 @@ const memberSchema = new Schema({
     required: true,
     minLength: 3,
     maxLength: 15,
-    match: /^[A-Za-z]+$/,
+    match: /^\w+(?:\s+\w+)*$/,
   },
   lastName: {
     type: String,
     required: true,
     minLength: 3,
     maxLength: 15,
-    match: /^[A-Za-z]+$/,
+    match: /^\w+(?:\s+\w+)*$/,
   },
   dni: {
     type: Number,


### PR DESCRIPTION
This PR is related to ticket 330 which required the correction of the regex in member model.
Now its possible to create a member using spaces in the firstName field.
It is not allowed to enter spaces at the beginning and end of the firstName field.
Also the lastName regex was corrected to work similar as the firstName field.