### PR TITLE
BaSP-MR-407: middleware created for error 413 manage

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,9 +1,11 @@
 const express = require('express');
 const cors = require('cors');
 const router = require('./routes');
+const fileSizeManage = require('./middlewares/fileSizeMiddleware');
 
 const app = express();
 
+app.use(fileSizeManage);
 app.use(cors());
 app.use(express.json());
 app.use('/api', router);

--- a/src/middlewares/fileSizeMiddleware.js
+++ b/src/middlewares/fileSizeMiddleware.js
@@ -1,0 +1,17 @@
+const fileSizeManage = (req, res, next) => {
+  if (!/^application\/json/.test(req.headers['content-type'])) {
+    return next();
+  }
+
+  const size = req.headers['content-length'];
+  if (size > 83000) {
+    return res.status(413).json({
+      message: 'Image loaded exceeds the allowed size',
+      data: null,
+      error: true,
+    });
+  }
+  return next();
+};
+
+module.exports = fileSizeManage;


### PR DESCRIPTION
- [x] I've created a middleware for managing the 413 (Payload too large) error before it gets to the routes and blow all backend in pieces.